### PR TITLE
Fix settings folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SABProxy is a DNS filtering adblocker (and track-blocker) proxy based on [Little
 SABProxy can be installed on any Linux OS (running systemd) using a simple bash script:
 
 <small>1.</small>`wget https://raw.githubusercontent.com/pgnunes/sabproxy/master/install/install-sabproxy.sh`
-<br/><small>2.</small>`sudo bash install-sabproxy.sh`
+<br/><small>2.</small>`sudo -E bash install-sabproxy.sh`
 
 ### Update
 SABProxy supports auto-updating. Once started please navigate to the 'Check Update' tab and update directly from the web interface.

--- a/install/install-sabproxy.sh
+++ b/install/install-sabproxy.sh
@@ -103,7 +103,7 @@ echo "Description=SABProxy" >> $SERVICE_FILE
 echo "After=syslog.target network.target" >> $SERVICE_FILE
 echo "" >> $SERVICE_FILE
 echo "[Service]" >> $SERVICE_FILE
-echo "SABPUser=sabproxy" >> $SERVICE_FILE
+echo "User=sabproxy" >> $SERVICE_FILE
 echo "ExecStart=/usr/bin/java -jar /opt/sabproxy/sabproxy.jar" >> $SERVICE_FILE
 echo "Restart=on-failure" >> $SERVICE_FILE
 echo "SuccessExitStatus=143" >> $SERVICE_FILE

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.sabproxy</groupId>
     <artifactId>sabproxy</artifactId>
-    <version>0.0.8-SNAPSHOT</version>
+    <version>0.0.9-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SABProxy</name>


### PR DESCRIPTION
This fixes the Linux install script where the "User" entry was incorrectly being created, preventing the service from starting under user 'sabproxy'