### PR TITLE
adding junit dependency; Removed all deprecations, unchecked warnings and encoding warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
             <version>1.1.2</version>
         </dependency>
 
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,14 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+	          <groupId>org.apache.maven.plugins</groupId>
+	          <artifactId>maven-resources-plugin</artifactId>
+	          <version>3.2.0</version>
+	          <configuration>
+		        <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+	          </configuration>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/sabproxy/util/AdServers.java
+++ b/src/main/java/com/sabproxy/util/AdServers.java
@@ -77,11 +77,8 @@ public class AdServers {
         }
 
         adServers = new ArrayList<String>();
-        LineIterator it = null;
         log.info("Loading Ad Server list from: " + adServersHostFile);
-        try {
-            it = FileUtils.lineIterator(new File(adServersHostFile), "UTF-8");
-
+        try (LineIterator it = FileUtils.lineIterator(new File(adServersHostFile), "UTF-8")) {
             while (it.hasNext()) {
                 String line = it.nextLine();
 
@@ -92,8 +89,6 @@ public class AdServers {
             log.info("Loaded " + adServers.size() + " ad servers.");
         } catch (Exception e) {
             log.error("Failed to load ad servers from file " + adServersHostFile + ". " + e.getMessage());
-        } finally {
-            LineIterator.closeQuietly(it);
         }
     }
 

--- a/src/main/java/com/sabproxy/util/HitCounter.java
+++ b/src/main/java/com/sabproxy/util/HitCounter.java
@@ -27,7 +27,7 @@ public class HitCounter {
     }
 
     public Map<String, Integer> getTopHits() {
-        Map<String, Integer> testMap = new HashMap(hitCounter);
+        Map<String, Integer> testMap = new HashMap<String, Integer>(hitCounter);
 
         return Utils.sortByValue(testMap);
 

--- a/src/main/java/com/sabproxy/util/HitCounter.java
+++ b/src/main/java/com/sabproxy/util/HitCounter.java
@@ -27,7 +27,7 @@ public class HitCounter {
     }
 
     public Map<String, Integer> getTopHits() {
-        Map<String, Integer> testMap = new HashMap(hitCounter);
+        Map<String, Integer> testMap = new HashMap<>(hitCounter);
 
         return Utils.sortByValue(testMap);
 

--- a/src/test/java/com/sabproxy/SystemInfoUtilTest.java
+++ b/src/test/java/com/sabproxy/SystemInfoUtilTest.java
@@ -5,7 +5,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Created by pnunes on 5/30/17.


### PR DESCRIPTION
The build fails tests due to no junit dependency. There are also unchecked and deprecation warnings, and an encoding warning. This pull request fixes them all.